### PR TITLE
Exported constructors, made the default type backend NoTypeInfo. Made Term a newtype.

### DIFF
--- a/Examples/DataKinds.hs
+++ b/Examples/DataKinds.hs
@@ -1,8 +1,8 @@
 module Pxamples.DataKinds where
 
 import Data.Kind (Type)
-import Plutarch.Pxperimental (PEq)
 import Plutarch.Prelude
+import Plutarch.Pxperimental (PEq)
 
 data Nat = N | S Nat
 data SNat :: Nat -> Type where

--- a/Plutarch/Core.hs
+++ b/Plutarch/Core.hs
@@ -316,7 +316,7 @@ class PDSL edsl => PAp (f :: Type -> Type) edsl where
   papl :: HasCallStack => Term edsl a -> f b -> Term edsl a
 
 class PAp m edsl => PEmbeds (m :: Type -> Type) edsl where
-  eembed :: HasCallStack => m (Term edsl a) -> Term edsl a
+  pembed :: HasCallStack => m (Term edsl a) -> Term edsl a
 
 data PIsProductR (edsl :: PDSLKind) (a :: [Type]) = forall inner.
   SOP.All (IsPType edsl) inner =>

--- a/Plutarch/Core.hs
+++ b/Plutarch/Core.hs
@@ -7,12 +7,11 @@ module Plutarch.Core (
   Compile,
   CompileAp,
   PRepr,
-  PDSLKind(..),
-  UnEDSLKind,
+  PDSLKind (..),
+  UnPDSLKind,
   Term (Term),
   ClosedTerm,
   IsPTypeBackend,
-  NoTypeInfo, 
   PHasRepr (..),
   PIsRepr (..),
   IsPType,
@@ -30,7 +29,7 @@ module Plutarch.Core (
   type (#=>),
   pattern PConstrained,
   PVoid,
-  PLet(..),
+  PLet (..),
   PDelay (PDelay),
   PPair (PPair),
   PEither (PLeft, PRight),
@@ -45,8 +44,6 @@ module Plutarch.Core (
   PDSL,
   PLC,
   unTerm,
-  plam,
-  plam2,
   (#),
   plet,
   punsafeCoerce,
@@ -54,7 +51,7 @@ module Plutarch.Core (
   PPartial,
   perror,
   PEmbeds,
-  eembed,
+  pembed,
   PAp,
   papr,
   papl,
@@ -70,12 +67,12 @@ import Data.Proxy (Proxy (Proxy))
 import GHC.Generics (Generic)
 import GHC.Stack (HasCallStack)
 import GHC.TypeLits (Symbol, TypeError, pattern ShowType, pattern Text, pattern (:$$:))
-import qualified Generics.SOP as SOP
-import qualified Generics.SOP.GGP as SOPG
+import Generics.SOP qualified as SOP
+import Generics.SOP.GGP qualified as SOPG
 import Plutarch.PType (
-  PPType,
   PGeneric,
   PHs,
+  PPType,
   PType,
   PTypeF,
   PfC,
@@ -86,8 +83,8 @@ import Plutarch.Reduce (NoReduce)
 
 newtype PDSLKind = PDSLKind (PType -> Type)
 
-type family UnEDSLKind (edsl :: PDSLKind) :: PType -> Type where
-  UnEDSLKind ( 'PDSLKind edsl) = edsl
+type family UnPDSLKind (edsl :: PDSLKind) :: PType -> Type where
+  UnPDSLKind ( 'PDSLKind edsl) = edsl
 
 newtype PReprKind = PReprKind Type
 
@@ -150,7 +147,7 @@ type PRepr :: PType -> PType
 type PRepr a = PReprApply (PReprSort a) a
 
 type NoTypeInfo :: forall k. PHs k -> Constraint
-class    NoTypeInfo a
+class NoTypeInfo a
 instance NoTypeInfo a
 
 class PDSL (edsl :: PDSLKind) where
@@ -159,7 +156,7 @@ class PDSL (edsl :: PDSLKind) where
 
 type role Term nominal nominal
 newtype Term (edsl :: PDSLKind) (a :: PType) where
-  Term :: {unTerm :: UnEDSLKind edsl (PRepr a) } -> Term edsl a
+  Term :: {unTerm :: UnPDSLKind edsl (PRepr a)} -> Term edsl a
 
 type ClosedTerm (c :: PDSLKind -> Constraint) (a :: PType) = forall edsl. c edsl => Term edsl a
 
@@ -205,10 +202,10 @@ type family Helper (edsl :: PDSLKind) :: PTypeF where
 type PConcrete (edsl :: PDSLKind) (a :: PType) = a (Helper edsl)
 
 class (PDSL edsl, IsPTypeBackend edsl a) => PConstructable' edsl (a :: PType) where
-  pconImpl :: HasCallStack => PConcrete edsl a -> UnEDSLKind edsl a
+  pconImpl :: HasCallStack => PConcrete edsl a -> UnPDSLKind edsl a
 
   -- If this didn't return `Term`, implementing it would be a lot harder.
-  pmatchImpl :: forall b. (HasCallStack, IsPType edsl b) => UnEDSLKind edsl a -> (PConcrete edsl a -> Term edsl b) -> Term edsl b
+  pmatchImpl :: forall b. (HasCallStack, IsPType edsl b) => UnPDSLKind edsl a -> (PConcrete edsl a -> Term edsl b) -> Term edsl b
 
 -- | The crux of what an eDSL is.
 class (PConstructable' edsl (PRepr a), PHasRepr a) => PConstructable edsl (a :: PType)
@@ -281,15 +278,6 @@ instance PHasRepr (PEither a b) where type PReprSort _ = PReprPrimitive
 
 type PLC :: PDSLKind -> Constraint
 type PLC edsl = forall a b. (IsPType edsl a, IsPType edsl b) => PConstructable edsl (a #-> b)
-
-plam :: forall edsl a b. (HasCallStack, PConstructable edsl (a #-> b)) => (Term edsl a -> Term edsl b) -> Term edsl (a #-> b)
-plam f = pcon $ (PLam f :: PConcrete edsl (a #-> b))
-
-plam2 :: PConstructable edsl (a #-> b #-> c)
-      => PConstructable edsl (b #-> c)
-      => (Term edsl a -> Term edsl b -> Term edsl c)
-      -> Term edsl (a #-> (b #-> c))
-plam2 body = plam \a -> plam \b -> body a b
 
 (#) :: (HasCallStack, PLC edsl, IsPType edsl a, IsPType edsl b) => Term edsl (a #-> b) -> Term edsl a -> Term edsl b
 (#) f x = pmatch f (\(PLam f') -> f' x)

--- a/Plutarch/Prelude.hs
+++ b/Plutarch/Prelude.hs
@@ -24,6 +24,7 @@ module Plutarch.Prelude (
 
 import GHC.Generics (Generic)
 import Plutarch.Core
+import Plutarch.Lam
 import Plutarch.PType
 
 ($$) :: PConstructable edsl a => (Term edsl a -> b) -> PConcrete edsl a -> b

--- a/Plutarch/SystemF.hs
+++ b/Plutarch/SystemF.hs
@@ -1,3 +1,4 @@
+{-
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -190,7 +191,6 @@ instance (Applicative m, TypeInfo m a, TypeInfo m b) => EConstructable' (Impl m)
   --ematchImpl f g = g $ ELam \(Term x) -> Term $ Impl \lvl -> runImpl f lvl `SFApp` runImpl x lvl
 {-
 
-
 instance EConstructable Impl EUnit where
   econ EUnit = Term $ Impl \_ -> SFUnit'
   ematch _ f = f EUnit
@@ -217,7 +217,6 @@ instance (forall a. TypeInfo a => TypeInfo (f a)) => EConstructable Impl (EForal
     in
     f $ EForall $ Term applied
 
-
 compile' :: forall a m. (Applicative m, IsEType (Impl m) a) => Term (Impl m) a -> m (SFTerm, SFType)
 compile' (Term t) = (,) <$> runImpl t SN <*> pure (typeInfo (Proxy @m) (Proxy @a) SN)
 
@@ -226,4 +225,5 @@ compile t = let _unused = callStack in compile' t
 
 compileAp :: CompileAp EDSL (SFTerm, SFType)
 compileAp t = let _unused = callStack in compile' t
+-}
 -}

--- a/bin/format
+++ b/bin/format
@@ -8,13 +8,11 @@ then
 	cabalfmt_mode="-c"
 	nixpkgsfmt_mode="--check"
 	echo check
-	exit 0
 else
 	fourmolu_mode="inplace"
 	cabalfmt_mode="-i"
 	nixpkgsfmt_mode=""
 	echo nocheck
-	exit 0
 fi
 
 find -type f -name '*.hs' ! -path '*/dist-newstyle/*' ! -path '*/tmp/*' | xargs fourmolu -o-XTypeApplications -o-XQualifiedDo -o-XOverloadedRecordDot -o-XNondecreasingIndentation -o-XPatternSynonyms -m "$fourmolu_mode"

--- a/flake.nix
+++ b/flake.nix
@@ -58,5 +58,11 @@
           ];
         };
       });
+      hydraJobs = {
+        checks = { inherit (self.checks) x86_64-linux; };
+        packages = { inherit (self.packages) x86_64-linux; };
+        devShells = { inherit (self.devShells) x86_64-linux; };
+        apps.x86_64-linux.regen = self.apps.x86_64-linux.regen.program;
+      };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -14,10 +14,27 @@
         };
       };
       hsPkgsFor = system: hsOverlay (pkgsFor system).haskell.packages.ghc923;
+      formattersFor = system: with (pkgsFor system); [
+        nixpkgs-fmt
+        haskellPackages.cabal-fmt
+        (hsPkgsFor system).fourmolu_0_7_0_1
+      ];
+      regen = system: (pkgsFor system).writeShellApplication {
+        name = "regen";
+        runtimeInputs = [ (pkgsFor system).cabal2nix ] ++ formattersFor system;
+        text = ''
+          set -xe
+          cabal2nix ./. > plutarch-core.nix
+          ./bin/format
+        '';
+      };
     in
     {
       checks = perSystem (system: {
-        formatting = (pkgsFor system).runCommandNoCC "formatting-check" { } ''
+        formatting = (pkgsFor system).runCommandNoCC "formatting-check"
+          {
+            nativeBuildInputs = formattersFor system;
+          } ''
           cd ${self}
           ./bin/format check
           touch $out
@@ -33,12 +50,7 @@
       });
       apps = perSystem (system: {
         regen.type = "app";
-        regen.program = builtins.toString ((pkgsFor system).writeShellScript "regen" ''
-          set -xe
-          export PATH="${(hsPkgsFor system).fourmolu_0_7_0_1}/bin:$PATH"
-          ${(pkgsFor system).cabal2nix}/bin/cabal2nix ./. > plutarch-core.nix
-          ./bin/format
-        '');
+        regen.program = "${regen system}/bin/regen";
       });
       packages = perSystem (system: {
         default = (hsPkgsFor system).plutarch-core;
@@ -51,18 +63,16 @@
             cabal-install
             hlint
             cabal2nix
-            nixpkgs-fmt
             curl
-            haskellPackages.cabal-fmt
-            (hsPkgsFor system).fourmolu_0_7_0_1
-          ];
+          ] ++ formattersFor system;
         };
       });
       hydraJobs = {
         checks = { inherit (self.checks) x86_64-linux; };
         packages = { inherit (self.packages) x86_64-linux; };
         devShells = { inherit (self.devShells) x86_64-linux; };
-        apps.x86_64-linux.regen = self.apps.x86_64-linux.regen.program;
+        apps.x86_64-linux.regen = regen "x86_64-linux";
       };
+      herculesCI.ciSystems = [ "x86_64-linux" ];
     };
 }

--- a/plutarch-core.cabal
+++ b/plutarch-core.cabal
@@ -6,8 +6,9 @@ license:            MIT
 extra-source-files: README.md
 
 library
-  default-language: GHC2021
+  default-language:   GHC2021
   default-extensions:
+    NoFlexibleInstances
     NoMonomorphismRestriction
     NoStarIsType
     BlockArguments
@@ -18,7 +19,6 @@ library
     DerivingVia
     DisambiguateRecordFields
     DuplicateRecordFields
-    NoFlexibleInstances
     FunctionalDependencies
     GADTs
     ImpredicativeTypes
@@ -52,22 +52,22 @@ library
 
   ghc-options:
     -Weverything -Wno-unused-do-bind -Wno-missing-kind-signatures
-    -Werror -Wno-implicit-prelude
-    -Wno-name-shadowing -Wno-unsafe -Wno-missing-safe-haskell-mode
-    -Wno-missing-local-signatures -Wno-prepositive-qualified-module
-    -Wno-missing-import-lists -Wno-all-missed-specializations
-    -Wno-unticked-promoted-constructors
+    -Werror -Wno-implicit-prelude -Wno-name-shadowing -Wno-unsafe
+    -Wno-missing-safe-haskell-mode -Wno-missing-local-signatures
+    -Wno-prepositive-qualified-module -Wno-missing-import-lists
+    -Wno-all-missed-specializations -Wno-unticked-promoted-constructors
     -fprint-explicit-kinds -fprint-explicit-coercions
     -fprint-equality-relations -fprint-explicit-foralls
 
   exposed-modules:
     Plutarch.Core
-    Plutarch.PType
     Plutarch.Experimental
-    Plutarch.Reduce
     Plutarch.Internal.WithDictHack
     Plutarch.Internal.Witness
+    Plutarch.Lam
     Plutarch.Prelude
+    Plutarch.PType
+    Plutarch.Reduce
 
   build-depends:
     , base


### PR DESCRIPTION
* Exported constructors from PDSLKind, PLet.
* Made NoTypeInfo the defaut IsPTypeBackend.
* Made Term a newtype and added plam2, it will be later replaced by the n-ary version.
* Renamed `eembed` to `pembed`