### PR TITLE
ULC Problem

### DIFF
--- a/Examples/ULC.hs
+++ b/Examples/ULC.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE PartialTypeSignatures #-}
+module Examples.ULC where
+
+import Plutarch.Core
+import Plutarch.ULC
+
+import Data.Proxy
+import Data.Functor.Identity
+import Plutarch.PType
+
+x :: forall (a :: PType) m. (IsPTypeBackend (ULCImpl m) a) => Proxy a -> ULC
+x _ = runIdentity . compile (Proxy @(a #-> a)) $ pcon (PLam id)

--- a/Examples/ULC.hs
+++ b/Examples/ULC.hs
@@ -8,5 +8,5 @@ import Data.Proxy
 import Data.Functor.Identity
 import Plutarch.PType
 
-x :: forall (a :: PType) m. (IsPTypeBackend (ULCImpl m) a) => Proxy a -> ULC
+x :: forall (a :: PType). (PHasRepr a) => Proxy a -> ULC
 x _ = runIdentity . compile (Proxy @(a #-> a)) $ pcon (PLam id)

--- a/Plutarch/ULC.hs
+++ b/Plutarch/ULC.hs
@@ -4,7 +4,8 @@
 {-# LANGUAGE UndecidableSuperClasses #-}
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
-module Plutarch.ULC (ULC (..), compileAp, compile) where
+module Plutarch.ULC (ULC, ULCImpl,
+ compileAp, compile) where
 
 import Data.Proxy
 

--- a/plutarch-core.cabal
+++ b/plutarch-core.cabal
@@ -70,6 +70,8 @@ library
     Plutarch.Reduce
     Plutarch.ULC
 
+    Examples.ULC
+
   build-depends:
     , base
     , generics-sop


### PR DESCRIPTION
```
Examples/ULC.hs:12:21: error:
    • Could not deduce: IsPTypeBackend
                          edsl
                          @PPType
                          (PReprApply (PReprSort a) a |> Sym (Plutarch.PType.D:R:PHs[0]))
        arising from a use of ‘compile’
      from the context: IsPTypeBackend
                          (ULCImpl m) @PPType (a |> Sym (Plutarch.PType.D:R:PHs[0]))
        bound by the type signature for:
                   x :: forall (a :: PType) (m :: Type -> Type).
                        IsPTypeBackend
                          (ULCImpl m) @PPType (a |> Sym (Plutarch.PType.D:R:PHs[0])) =>
                        Proxy @{PType} a -> ULC
        at Examples/ULC.hs:11:1-76
      or from: Plutarch.ULC.PULC edsl
        bound by a quantified context at Examples/ULC.hs:1:1
    • In the second argument of ‘(.)’, namely
        ‘compile (Proxy @(a #-> a))’
      In the first argument of ‘($)’, namely
        ‘runIdentity . compile (Proxy @(a #-> a))’
      In the expression:
        runIdentity . compile (Proxy @(a #-> a)) $ pcon (PLam id)
    • Relevant bindings include
        x :: Proxy @{PType} a -> ULC (bound at Examples/ULC.hs:12:1)
   |
12 | x _ = runIdentity . compile (Proxy @(a #-> a)) $ pcon (PLam id)
   |                     ^^^^^^^

Examples/ULC.hs:12:21: error:
    • Could not deduce (PHasRepr a) arising from a use of ‘compile’
      from the context: IsPTypeBackend
                          (ULCImpl m) @PPType (a |> Sym (Plutarch.PType.D:R:PHs[0]))
        bound by the type signature for:
                   x :: forall (a :: PType) (m :: Type -> Type).
                        IsPTypeBackend
                          (ULCImpl m) @PPType (a |> Sym (Plutarch.PType.D:R:PHs[0])) =>
                        Proxy @{PType} a -> ULC
        at Examples/ULC.hs:11:1-76
      or from: Plutarch.ULC.PULC edsl
        bound by a quantified context at Examples/ULC.hs:1:1
      Possible fix:
        add (PHasRepr a) to the context of
          a quantified context
          or the type signature for:
               x :: forall (a :: PType) (m :: Type -> Type).
                    IsPTypeBackend
                      (ULCImpl m) @PPType (a |> Sym (Plutarch.PType.D:R:PHs[0])) =>
                    Proxy @{PType} a -> ULC
    • In the second argument of ‘(.)’, namely
        ‘compile (Proxy @(a #-> a))’
      In the first argument of ‘($)’, namely
        ‘runIdentity . compile (Proxy @(a #-> a))’
      In the expression:
        runIdentity . compile (Proxy @(a #-> a)) $ pcon (PLam id)
   |
12 | x _ = runIdentity . compile (Proxy @(a #-> a)) $ pcon (PLam id)
   |                     ^^^^^^^

Examples/ULC.hs:12:50: error:
    • Could not deduce: IsPTypeBackend
                          edsl
                          @PPType
                          (PReprApply (PReprSort a) a |> Sym (Plutarch.PType.D:R:PHs[0]))
        arising from a use of ‘pcon’
      from the context: IsPTypeBackend
                          (ULCImpl m) @PPType (a |> Sym (Plutarch.PType.D:R:PHs[0]))
        bound by the type signature for:
                   x :: forall (a :: PType) (m :: Type -> Type).
                        IsPTypeBackend
                          (ULCImpl m) @PPType (a |> Sym (Plutarch.PType.D:R:PHs[0])) =>
                        Proxy @{PType} a -> ULC
        at Examples/ULC.hs:11:1-76
      or from: (Plutarch.ULC.PULC edsl, PEmbeds Identity edsl)
        bound by a type expected by the context:
                   forall (edsl :: PDSLKind).
                   (Plutarch.ULC.PULC edsl, PEmbeds Identity edsl) =>
                   Term edsl (a #-> a)
        at Examples/ULC.hs:12:50-63
    • In the second argument of ‘($)’, namely ‘pcon (PLam id)’
      In the expression:
        runIdentity . compile (Proxy @(a #-> a)) $ pcon (PLam id)
      In an equation for ‘x’:
          x _ = runIdentity . compile (Proxy @(a #-> a)) $ pcon (PLam id)
    • Relevant bindings include
        x :: Proxy @{PType} a -> ULC (bound at Examples/ULC.hs:12:1)
   |
12 | x _ = runIdentity . compile (Proxy @(a #-> a)) $ pcon (PLam id)
   |                                                  ^^^^

Examples/ULC.hs:12:50: error:
    • Could not deduce (PHasRepr a) arising from a use of ‘pcon’
      from the context: IsPTypeBackend
                          (ULCImpl m) @PPType (a |> Sym (Plutarch.PType.D:R:PHs[0]))
        bound by the type signature for:
                   x :: forall (a :: PType) (m :: Type -> Type).
                        IsPTypeBackend
                          (ULCImpl m) @PPType (a |> Sym (Plutarch.PType.D:R:PHs[0])) =>
                        Proxy @{PType} a -> ULC
        at Examples/ULC.hs:11:1-76
      or from: (Plutarch.ULC.PULC edsl, PEmbeds Identity edsl)
        bound by a type expected by the context:
                   forall (edsl :: PDSLKind).
                   (Plutarch.ULC.PULC edsl, PEmbeds Identity edsl) =>
                   Term edsl (a #-> a)
        at Examples/ULC.hs:12:50-63
      Possible fix:
        add (PHasRepr a) to the context of
          a type expected by the context:
            forall (edsl :: PDSLKind).
            (Plutarch.ULC.PULC edsl, PEmbeds Identity edsl) =>
            Term edsl (a #-> a)
          or the type signature for:
               x :: forall (a :: PType) (m :: Type -> Type).
                    IsPTypeBackend
                      (ULCImpl m) @PPType (a |> Sym (Plutarch.PType.D:R:PHs[0])) =>
                    Proxy @{PType} a -> ULC
    • In the second argument of ‘($)’, namely ‘pcon (PLam id)’
      In the expression:
        runIdentity . compile (Proxy @(a #-> a)) $ pcon (PLam id)
      In an equation for ‘x’:
          x _ = runIdentity . compile (Proxy @(a #-> a)) $ pcon (PLam id)
   |
12 | x _ = runIdentity . compile (Proxy @(a #-> a)) $ pcon (PLam id)
   |                                                  ^^^^
```